### PR TITLE
Add kokkos stuff

### DIFF
--- a/kokkos.py
+++ b/kokkos.py
@@ -1,0 +1,48 @@
+from . import generic
+
+from waflib import Task
+from waflib.TaskGen import extension
+from waflib.Tools import ccroot, c_preproc
+from waflib.Configure import conf
+
+import os
+
+# from waf's playground
+class kokkos_cuda(Task.Task):
+    run_str = '${NVCC} ${NVCCFLAGS} ${FRAMEWORKPATH_ST:FRAMEWORKPATH} ${CPPPATH_ST:INCPATHS} ${DEFINES_ST:DEFINES} ${CXX_SRC_F}${SRC} ${CXX_TGT_F} ${TGT}'
+    color   = 'GREEN'
+    ext_in  = ['.h']
+    vars    = ['CCDEPS']
+    scan    = c_preproc.scan
+    shell   = False
+
+@extension('.kokkos')
+def kokkos_hook(self, node):
+    options = getattr(self.env, 'KOKKOS_OPTIONS', None)
+    if 'cuda' in options:
+        print('use nvcc on ', node)
+        return self.create_compiled_task('kokkos_cuda', node)
+    else:
+        return self.create_compiled_task('cxx', node)
+
+def options(opt):
+    generic._options(opt, "KOKKOS")
+    opt.add_option('--kokkos-options', type='string', help="cuda, ...")
+
+def configure(cfg):
+    generic._configure(cfg, "KOKKOS", mandatory=False,
+                       incs=["Kokkos_Macros.hpp"], libs=["kokkoscore", "kokkoscontainers", "dl"], bins=["nvcc"])
+
+    options = getattr(cfg.options, 'kokkos_options', None)
+    setattr(cfg.env, 'KOKKOS_OPTIONS', options)
+    options = getattr(cfg.env, 'KOKKOS_OPTIONS', None)
+    print('KOKKOS_OPTIONS                           :', options)
+
+    if not 'HAVE_KOKKOS' in cfg.env:
+        return
+    nvccflags = "-x cu -shared -Xcompiler -fPIC "
+    # nvccflags += "--std=c++11 "
+    nvccflags += "-Xcudafe --diag_suppress=esa_on_defaulted_function_ignored -expt-extended-lambda -arch=sm_75 -Xcompiler -fopenmp "
+    nvccflags += os.environ.get("NVCCFLAGS","")
+    cfg.env.NVCCFLAGS += nvccflags.strip().split()
+    print ("KOKKOS: NVCCFLAGS = %s" % (' '.join(cfg.env.NVCCFLAGS)))

--- a/kokkos.py
+++ b/kokkos.py
@@ -45,7 +45,8 @@ def configure(cfg):
     options = getattr(cfg.options, 'kokkos_options', None)
     setattr(cfg.env, 'KOKKOS_OPTIONS', options)
     options = getattr(cfg.env, 'KOKKOS_OPTIONS', None)
-    print('KOKKOS_OPTIONS                           :', options)
+    cfg.start_msg("KOKKOS_OPTIONS:")
+    cfg.end_msg(str(options))
 
     if not 'HAVE_KOKKOS' in cfg.env:
         return
@@ -56,5 +57,7 @@ def configure(cfg):
     cfg.env.KOKKOS_NVCCFLAGS += nvccflags.strip().split()
     cxxflags = " -x c++ "
     cfg.env.KOKKOS_CXXFLAGS += cxxflags.strip().split()
-    print ("KOKKOS_NVCCFLAGS = %s" % (' '.join(cfg.env.KOKKOS_NVCCFLAGS)))
-    print ("KOKKOS_CXXFLAGS = %s" % (' '.join(cfg.env.KOKKOS_CXXFLAGS)))
+    cfg.start_msg("KOKKOS_NVCCFLAGS:")
+    cfg.end_msg(str(cfg.env.KOKKOS_NVCCFLAGS))
+    cfg.start_msg("KOKKOS_CXXFLAGS:")
+    cfg.end_msg(str(cfg.env.KOKKOS_CXXFLAGS))

--- a/smplpkgs.py
+++ b/smplpkgs.py
@@ -201,12 +201,12 @@ def smplpkg(bld, name, use='', app_use='', test_use=''):
                         use = app_use + [name])
 
 
-    if (testsrc or test_scripts) and not bld.options.no_tests:
+    if (testsrc or testsrc_kokkos or test_scripts) and not bld.options.no_tests:
         for test_main in testsrc_kokkos:
             #print 'Building %s test: %s' % (name, test_main)
             rpath = get_rpath(test_use + [name])
             #print rpath
-            bld.program(features = 'cxx test', 
+            bld.program(features = 'cxx cxxprogram test', 
                         source = [test_main], 
                         ut_cwd   = bld.path, 
                         target = test_main.name.replace('.kokkos',''),

--- a/smplpkgs.py
+++ b/smplpkgs.py
@@ -203,11 +203,10 @@ def smplpkg(bld, name, use='', app_use='', test_use=''):
 
     if (testsrc or test_scripts) and not bld.options.no_tests:
         for test_main in testsrc_kokkos:
-            print('bld: ', bld)
             #print 'Building %s test: %s' % (name, test_main)
             rpath = get_rpath(test_use + [name])
             #print rpath
-            bld.program(features = 'test', 
+            bld.program(features = 'cxx test', 
                         source = [test_main], 
                         ut_cwd   = bld.path, 
                         target = test_main.name.replace('.kokkos',''),

--- a/smplpkgs.py
+++ b/smplpkgs.py
@@ -76,7 +76,6 @@ def configure(cfg):
     cfg.load('rpathify')
 
     cfg.env.append_unique('CXXFLAGS',['-std=c++17'])
-    cfg.env.append_unique('CXXFLAGS',['-fopenmp'])
 
     cfg.find_program('python', var='PYTHON', mandatory=True)
     cfg.find_program('bash', var='BASH', mandatory=True)

--- a/wcb.py
+++ b/wcb.py
@@ -47,6 +47,7 @@ def options(opt):
     opt.load('smplpkgs')
     opt.load('rootsys')
     opt.load('cuda')
+    opt.load('kokkos')
     #opt.load('protobuf')
 
     for name,desc in package_descriptions:
@@ -78,6 +79,11 @@ def configure(cfg):
         print ("sans CUDA")
     else:
         cfg.load('cuda')
+
+    if getattr(cfg.options, "with_kokkos", False) is False:
+        print ("sans KOKKOS")
+    else:
+        cfg.load('kokkos')
 
     if getattr(cfg.options, "with_root", False) is False:
         print ("sans ROOT")


### PR DESCRIPTION
@brettviren as we discussed yesterday, I added some kokkos stuff by copying the cuda.py. Kokkos-cuda needs specific cuda options. So I added those options in the kokkos.py.

**This is not fully working right now. Just think this maybe easier to communicate.**

I added `kokkos-options` to manually config how `.kokkos` files should be compiled. I just tested kokkos-cuda. I am working on testing kokko-omp.

This works OK for `.kokkos` sources code in the `src` fold. It gives me error msg if I try to put some `.kokkos` files in the `test` folder. Any ideas how to fix this?
```
Build failed
Traceback (most recent call last):
  File "/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/.waf3-2.0.20-88888387641ed0f5c08dd6187360302f/waflib/Tools/c_preproc.py", line 663, in scan
    incn=task.generator.includes_nodes
AttributeError: 'task_gen' object has no attribute 'includes_nodes'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/.waf3-2.0.20-88888387641ed0f5c08dd6187360302f/waflib/Runner.py", line 255, in task_status
    return tsk.runnable_status()
  File "/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/.waf3-2.0.20-88888387641ed0f5c08dd6187360302f/waflib/Task.py", line 372, in runnable_status
    new_sig=self.signature()
  File "/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/.waf3-2.0.20-88888387641ed0f5c08dd6187360302f/waflib/Task.py", line 357, in signature
    self.sig_implicit_deps()
  File "/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/.waf3-2.0.20-88888387641ed0f5c08dd6187360302f/waflib/Task.py", line 456, in sig_implicit_deps
    (bld.node_deps[key],bld.raw_deps[key])=self.scan()
  File "/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/.waf3-2.0.20-88888387641ed0f5c08dd6187360302f/waflib/Tools/c_preproc.py", line 665, in scan
    raise Errors.WafError('%r is missing a feature such as "c", "cxx" or "includes": '%task.generator)
waflib.Errors.WafError: bld(source=[/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos/test/test_atadd.kokkos], target='test_atadd', meths=['make_test', 'process_rule', 'process_source'], features=['test'], path=/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos, idx=3, tg_idx_count=3, ut_cwd=/home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos, install_path=None, includes=['inc', 'test', 'tests'], use=['BOOST', 'CUDA', 'EIGEN', 'FFTW', 'JSONCPP', 'KOKKOS', 'WCT', 'WireCellGen', 'WireCellIface', 'WireCellUtil', 'WireCellGenKokkos'], typ='program', _name='test_atadd', posted=True) in /home/yuhw/wc/wct-analysis/csi-kokkos/wire-cell-gen-kokkos is missing a feature such as "c", "cxx" or "includes":
```

